### PR TITLE
Fix Mermaid dotted-edge syntax in architecture diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,8 +70,8 @@ flowchart LR
   NodeB --> SVC
   SVC --> POD[hello Pod (NGINX + SPA)]
 
-  %% control plane relations (dashed)
-  CP -. Kubernetes API (public / opt. private) .- NodeA
+  %% control plane relations (dotted)
+  CP -. "Kubernetes API (public / opt. private)" .-> NodeA
   CP -.-> NodeB
 
   %% styles (apply classes after nodes are declared)
@@ -90,8 +90,8 @@ flowchart LR
   class NodeA,NodeB node
   class SVC svc
   class POD pod
-```
 
+```
 ---
 
 ## Diagram — Request sequence


### PR DESCRIPTION
Mermaid requires dotted edges **with labels** to use the form `A -. "label" .-> B`.  
This replaces the invalid line:
```
CP -. Kubernetes API (public / opt. private) .- NodeA
```
with the valid syntax:
```
CP -. "Kubernetes API (public / opt. private)" .-> NodeA
```
This resolves the GitHub renderer parse error.