### PR TITLE
Fix Mermaid labels and dotted-edge in architecture diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,16 +46,26 @@ This project provisions a **minimal, low-cost Amazon EKS environment** for quick
 %%{init: {
   "theme": "base",
   "themeVariables": {
+    "fontSize": "16px",
+
+    /* Make connectors visible in light & dark */
+    "lineColor": "#2563eb",
+    "primaryBorderColor": "#2563eb",
+
+    /* Nodes default to white cards with dark text for contrast on dark UIs */
     "primaryColor": "#ffffff",
     "primaryTextColor": "#111111",
-    "primaryBorderColor": "#111111",
-    "lineColor": "#111111",
-    "fontSize": "16px",
+
+    /* Subgraph (cluster) styling */
+    "clusterBkg": "#f8fafc",
+    "clusterBorder": "#2563eb",
+
+    /* Keep edge labels readable */
     "edgeLabelBackground": "#ffffff"
   }
 }}%%
 flowchart LR
-  %% declare nodes (no classes inline)
+  %% declare nodes (quote labels that have parentheses or <br/>)
   Internet((Client))
   NLB["NLB (internet-facing)"]
   CP["EKS Control Plane (v1.30)<br/>AWS-managed"]
@@ -73,7 +83,7 @@ flowchart LR
     end
   end
 
-  %% edges
+  %% edges (blue for visibility in both themes)
   Internet -->|HTTP:80| NLB
   NLB -->|"TCP:80 → NodePort 31080"| NodeA
   NLB -->|"TCP:80 → NodePort 31080"| NodeB
@@ -81,23 +91,23 @@ flowchart LR
   NodeB --> SVC
   SVC --> POD["hello Pod (NGINX + SPA)"]
 
-  %% control plane relations (dotted, high contrast)
+  %% control plane relations (dashed + orange to distinguish)
   CP -. "Kubernetes API (public / opt. private)" .-> NodeA
   CP -.-> NodeB
 
   %% high-contrast styles
-  %% subgraphs: thicker borders for boxes
-  style VPC fill:#f8fafc,stroke:#111111,stroke-width:2px,color:#111111
-  style SubnetA fill:#ffffff,stroke:#111111,stroke-width:1.5px,color:#111111
-  style SubnetB fill:#ffffff,stroke:#111111,stroke-width:1.5px,color:#111111
+  style VPC fill:#f8fafc,stroke:#2563eb,stroke-width:2px,color:#111111
+  style SubnetA fill:#ffffff,stroke:#94a3b8,stroke-width:1.5px,color:#111111
+  style SubnetB fill:#ffffff,stroke:#94a3b8,stroke-width:1.5px,color:#111111
 
-  %% emphases: dark fills + white text
-  classDef emphasis fill:#0b5394,color:#ffffff,stroke:#111111,stroke-width:2px;
-  classDef emphasisAlt fill:#1f2937,color:#ffffff,stroke:#111111,stroke-width:2px;
-
+  %% emphasize key components with dark fills + white text
+  classDef emphasis fill:#0b5394,color:#ffffff,stroke:#0b5394,stroke-width:2px;
   class NLB emphasis
-  class CP emphasisAlt
+  class CP emphasis
 
+  %% make control-plane links orange & dashed for visibility
+  %% (these are the last two links in order → indices 6 and 7)
+  linkStyle 6,7 stroke:#f59e0b,stroke-width:2px,stroke-dasharray:4 3;
 ```
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,17 @@ This project provisions a **minimal, low-cost Amazon EKS environment** for quick
 ## Diagram — Logical layout
 
 ```mermaid
+%%{init: {
+  "theme": "base",
+  "themeVariables": {
+    "primaryColor": "#ffffff",
+    "primaryTextColor": "#111111",
+    "primaryBorderColor": "#111111",
+    "lineColor": "#111111",
+    "fontSize": "16px",
+    "edgeLabelBackground": "#ffffff"
+  }
+}}%%
 flowchart LR
   %% declare nodes (no classes inline)
   Internet((Client))
@@ -70,26 +81,22 @@ flowchart LR
   NodeB --> SVC
   SVC --> POD["hello Pod (NGINX + SPA)"]
 
-  %% control plane relations (dotted)
+  %% control plane relations (dotted, high contrast)
   CP -. "Kubernetes API (public / opt. private)" .-> NodeA
   CP -.-> NodeB
 
-  %% styles (apply classes after nodes are declared)
-  classDef ext fill:#ffffff,stroke:#666,stroke-width:1px;
-  classDef alb fill:#eef6ff,stroke:#3b82f6,stroke-width:1px;
-  classDef cp  fill:#fff4e5,stroke:#f59e0b,stroke-width:1px;
-  classDef net fill:#f3f4f6,stroke:#9ca3af,stroke-width:1px;
-  classDef node fill:#ecfdf5,stroke:#10b981,stroke-width:1px;
-  classDef svc fill:#ede9fe,stroke:#8b5cf6,stroke-width:1px;
-  classDef pod fill:#e0f2fe,stroke:#38bdf8,stroke-width:1px;
+  %% high-contrast styles
+  %% subgraphs: thicker borders for boxes
+  style VPC fill:#f8fafc,stroke:#111111,stroke-width:2px,color:#111111
+  style SubnetA fill:#ffffff,stroke:#111111,stroke-width:1.5px,color:#111111
+  style SubnetB fill:#ffffff,stroke:#111111,stroke-width:1.5px,color:#111111
 
-  class Internet ext
-  class NLB alb
-  class CP cp
-  class IGW,RT net
-  class NodeA,NodeB node
-  class SVC svc
-  class POD pod
+  %% emphases: dark fills + white text
+  classDef emphasis fill:#0b5394,color:#ffffff,stroke:#111111,stroke-width:2px;
+  classDef emphasisAlt fill:#1f2937,color:#ffffff,stroke:#111111,stroke-width:2px;
+
+  class NLB emphasis
+  class CP emphasisAlt
 
 ```
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -47,20 +47,12 @@ This project provisions a **minimal, low-cost Amazon EKS environment** for quick
   "theme": "base",
   "themeVariables": {
     "fontSize": "16px",
-
-    /* High-contrast connectors */
     "lineColor": "#2563eb",
     "primaryBorderColor": "#2563eb",
-
-    /* Node cards: readable on dark UIs */
     "primaryColor": "#ffffff",
     "primaryTextColor": "#111111",
-
-    /* Default cluster (subgraph) look */
-    "clusterBkg": "#f3f4f6",
+    "clusterBkg": "#e8eefc",
     "clusterBorder": "#2563eb",
-
-    /* Edge labels stay legible */
     "edgeLabelBackground": "#ffffff"
   }
 }}%%
@@ -91,25 +83,21 @@ flowchart LR
   NodeB --> SVC
   SVC --> POD["hello Pod (NGINX + SPA)"]
 
-  %% control plane relations (dashed + orange to distinguish)
+  %% control plane relations (dashed)
   CP -. "Kubernetes API (public / opt. private)" .-> NodeA
   CP -.-> NodeB
 
   %% harmonious, dark-mode safe styling
-  /* VPC gets a blue-gray background (not white) */
   style VPC fill:#e8eefc,stroke:#2563eb,stroke-width:2px,color:#111111
-
-  /* Subnets: subtle gray to separate from VPC */
   style SubnetA fill:#f3f4f6,stroke:#94a3b8,stroke-width:1.5px,color:#111111
   style SubnetB fill:#f3f4f6,stroke:#94a3b8,stroke-width:1.5px,color:#111111
 
-  /* Emphasize key components with dark fills + white text */
+  %% emphasize key components with dark fills + white text
   classDef emphasis fill:#0b5394,color:#ffffff,stroke:#0b5394,stroke-width:2px;
   class NLB emphasis
   class CP emphasis
 
-  /* Make control-plane links orange & dashed for visibility */
-  /* (last two links in order → indices 6 and 7) */
+  %% make control-plane links orange & dashed for visibility (edges #6 and #7)
   linkStyle 6,7 stroke:#f59e0b,stroke-width:2px,stroke-dasharray:4 3;
 
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,7 +46,7 @@ This project provisions a **minimal, low-cost Amazon EKS environment** for quick
 flowchart LR
   %% declare nodes (no classes inline)
   Internet((Client))
-  NLB[NLB (internet-facing)]
+  NLB["NLB (internet-facing)"]
   CP["EKS Control Plane (v1.30)<br/>AWS-managed"]
 
   subgraph VPC["VPC 10.0.0.0/16"]
@@ -68,7 +68,7 @@ flowchart LR
   NLB -->|"TCP:80 → NodePort 31080"| NodeB
   NodeA --> SVC[ClusterIP Service]
   NodeB --> SVC
-  SVC --> POD[hello Pod (NGINX + SPA)]
+  SVC --> POD["hello Pod (NGINX + SPA)"]
 
   %% control plane relations (dotted)
   CP -. "Kubernetes API (public / opt. private)" .-> NodeA

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,19 +48,19 @@ This project provisions a **minimal, low-cost Amazon EKS environment** for quick
   "themeVariables": {
     "fontSize": "16px",
 
-    /* Make connectors visible in light & dark */
+    /* High-contrast connectors */
     "lineColor": "#2563eb",
     "primaryBorderColor": "#2563eb",
 
-    /* Nodes default to white cards with dark text for contrast on dark UIs */
+    /* Node cards: readable on dark UIs */
     "primaryColor": "#ffffff",
     "primaryTextColor": "#111111",
 
-    /* Subgraph (cluster) styling */
-    "clusterBkg": "#f8fafc",
+    /* Default cluster (subgraph) look */
+    "clusterBkg": "#f3f4f6",
     "clusterBorder": "#2563eb",
 
-    /* Keep edge labels readable */
+    /* Edge labels stay legible */
     "edgeLabelBackground": "#ffffff"
   }
 }}%%
@@ -95,19 +95,23 @@ flowchart LR
   CP -. "Kubernetes API (public / opt. private)" .-> NodeA
   CP -.-> NodeB
 
-  %% high-contrast styles
-  style VPC fill:#f8fafc,stroke:#2563eb,stroke-width:2px,color:#111111
-  style SubnetA fill:#ffffff,stroke:#94a3b8,stroke-width:1.5px,color:#111111
-  style SubnetB fill:#ffffff,stroke:#94a3b8,stroke-width:1.5px,color:#111111
+  %% harmonious, dark-mode safe styling
+  /* VPC gets a blue-gray background (not white) */
+  style VPC fill:#e8eefc,stroke:#2563eb,stroke-width:2px,color:#111111
 
-  %% emphasize key components with dark fills + white text
+  /* Subnets: subtle gray to separate from VPC */
+  style SubnetA fill:#f3f4f6,stroke:#94a3b8,stroke-width:1.5px,color:#111111
+  style SubnetB fill:#f3f4f6,stroke:#94a3b8,stroke-width:1.5px,color:#111111
+
+  /* Emphasize key components with dark fills + white text */
   classDef emphasis fill:#0b5394,color:#ffffff,stroke:#0b5394,stroke-width:2px;
   class NLB emphasis
   class CP emphasis
 
-  %% make control-plane links orange & dashed for visibility
-  %% (these are the last two links in order → indices 6 and 7)
+  /* Make control-plane links orange & dashed for visibility */
+  /* (last two links in order → indices 6 and 7) */
   linkStyle 6,7 stroke:#f59e0b,stroke-width:2px,stroke-dasharray:4 3;
+
 ```
 ---
 


### PR DESCRIPTION
Wrap node labels containing parentheses in quotes (GitHub Mermaid requires this) and correct the dotted-edge syntax to `-. "label" .->`.